### PR TITLE
fixed issue with useLog (nangyari nung meeting)

### DIFF
--- a/logbooktest.c
+++ b/logbooktest.c
@@ -166,6 +166,14 @@ int useLog(log **head, Profile * pHead, int * car, int * motor, int option)
                     return 0;
                 }
             }
+            else if(p->next == NULL)
+            {
+                 if((p->status == 0 && q == NULL))
+                {
+                    printf("User already logged out. Exiting Log Out.\n");
+                    return 0;
+                }
+            }
             while((strcmp(p->plateNum, tempNo) != 0) && p->next != NULL)
             {
                 q = p->next;
@@ -186,7 +194,7 @@ int useLog(log **head, Profile * pHead, int * car, int * motor, int option)
             //CHECK FOR DISCREPANCY
             dscrpncyCheck(pHead, tempNo, tempID);
             //find platenumber to log out
-            if(p->status != 0)
+            if((strcmp(p->plateNum, tempNo) == 0) && (strcmp(p->profileID, tempID) == 0) && p->status != 0)
             {             
                 t = time(NULL);
                 p->timeOut = *localtime(&t);

--- a/mainSrcCode.c
+++ b/mainSrcCode.c
@@ -736,6 +736,14 @@ void dscrpncyCheck(Profile * head, const char *plate[], const char *id[]){
                     return 0;
                 }
             }
+            else if(p->next == NULL)
+            {
+                 if((p->status == 0 && q == NULL))
+                {
+                    printf("User already logged out. Exiting Log Out.\n");
+                    return 0;
+                }
+            }
             while((strcmp(p->plateNum, tempNo) != 0) && p->next != NULL)
             {
                 q = p->next;
@@ -756,7 +764,7 @@ void dscrpncyCheck(Profile * head, const char *plate[], const char *id[]){
             //CHECK FOR DISCREPANCY
             dscrpncyCheck(pHead, tempNo, tempID);
             //find platenumber to log out
-            if(p->status != 0)
+            if((strcmp(p->plateNum, tempNo) == 0) && (strcmp(p->profileID, tempID) == 0) && p->status != 0)
             {             
                 t = time(NULL);
                 p->timeOut = *localtime(&t);


### PR DESCRIPTION
FIXED ERROR WITH USELOG

Reason:  Logs out first logged in user even if entered number and id does not match
Fix: No longer logs out such cases and prompts a Driver not logged in text